### PR TITLE
[Pyxis Elm] Fix Accordion Documentation

### DIFF
--- a/packages/pyxis-elm/src/Stories/Chapters/Accordion.elm
+++ b/packages/pyxis-elm/src/Stories/Chapters/Accordion.elm
@@ -59,7 +59,8 @@ update msg model =
 -}
 accordion : Html msg
 accordion =
-    Accordion.config accordionItems
+    Accordion.config "my-accordion"
+        |> Accordion.withItems accordionItems
         |> Accordion.render Model.AccordionChanged model.accordion
 
 
@@ -133,7 +134,8 @@ The variants allow you to change the color scheme of the accordion.
 ```
 accordion : Html msg
 accordion =
-    Accordion.config accordionItems
+    Accordion.config "light-accordion"
+        |> Accordion.withItems accordionItems
         |> Accordion.withLightVariant
         |> Accordion.render Model.AccordionChanged model.accordion
 ```
@@ -146,7 +148,8 @@ You can set your Accordion with a default _theme_ or alternative. Alt theme is m
 ```
 accordion : Html msg
 accordion =
-    Accordion.config accordionItems
+    Accordion.config "alternative-theme-accordion"
+        |> Accordion.withItems accordionItems
         |> Accordion.withTheme Theme.alternative
         |> Accordion.render Model.AccordionChanged model.accordion
 ```


### PR DESCRIPTION
The elm book documentation related to Accordion seems to be wrong, `Accordion.config` receives an id as String instead of the list of AccordionItem